### PR TITLE
feat: skeleton loading for daily forecast

### DIFF
--- a/assets/placeholder.svg
+++ b/assets/placeholder.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <rect width="64" height="64" fill="#ccc" />
+</svg>

--- a/css/wx.css
+++ b/css/wx.css
@@ -98,6 +98,34 @@ body.dark-mode {
     max-width: 1100px;
 }
 
+/* Loading skeleton for forecast panels */
+@keyframes forecastLoading {
+    0% { background-position: -200px 0; }
+    100% { background-position: calc(200px + 100%) 0; }
+}
+
+.forecast-container.loading .forecast-day {
+    background: #e0e0e0;
+    background-image: linear-gradient(90deg, #e0e0e0 0, #f5f5f5 40px, #e0e0e0 80px);
+    background-size: 200px 100%;
+    animation: forecastLoading 1.5s infinite linear;
+}
+
+.forecast-container.loading .forecast-date,
+.forecast-container.loading .forecast-temp,
+.forecast-container.loading .forecast-desc {
+    color: #999;
+}
+
+.forecast-container.loading .forecast-icon {
+    filter: grayscale(100%);
+    opacity: 0.3;
+}
+
+.forecast-container.loading .forecast-alert {
+    display: none;
+}
+
 .forecast-day {
     border-radius: var(--button-radius);
     padding: 15px;

--- a/index.html
+++ b/index.html
@@ -156,55 +156,54 @@
 
         <div id="weather" class="section">
             <h2>Extended Forecast</h2>
-            <div id="prem-forecast-loading" class="content-loading"></div>
-            <div id="prem-forecast-container" class="forecast-container hidden">
+            <div id="prem-forecast-container" class="forecast-container loading">
                 <div class="forecast-day hourly-avail" onclick="showPremiumHourlyForecast(0)">
-                    <div class="forecast-date"></div>
-                    <img class="forecast-icon" src="">
-                    <div class="forecast-temp"></div>
-                    <div class="forecast-desc"></div>
+                    <div class="forecast-date">--</div>
+                    <img class="forecast-icon" src="assets/placeholder.svg" alt="Loading icon">
+                    <div class="forecast-temp">--</div>
+                    <div class="forecast-desc">--</div>
                     <img class="forecast-alert hidden" src="assets/warn.svg" alt="Warning Icon">
                 </div>
                 <div class="forecast-day hourly-avail" onclick="showPremiumHourlyForecast(1)">
-                    <div class="forecast-date"></div>
-                    <img class="forecast-icon" src="">
-                    <div class="forecast-temp"></div>
-                    <div class="forecast-desc"></div>
+                    <div class="forecast-date">--</div>
+                    <img class="forecast-icon" src="assets/placeholder.svg" alt="Loading icon">
+                    <div class="forecast-temp">--</div>
+                    <div class="forecast-desc">--</div>
                     <img class="forecast-alert hidden" src="assets/warn.svg" alt="Warning Icon">
                 </div>
                 <div class="forecast-day">
-                    <div class="forecast-date"></div>
-                    <img class="forecast-icon" src="">
-                    <div class="forecast-temp"></div>
-                    <div class="forecast-desc"></div>
+                    <div class="forecast-date">--</div>
+                    <img class="forecast-icon" src="assets/placeholder.svg" alt="Loading icon">
+                    <div class="forecast-temp">--</div>
+                    <div class="forecast-desc">--</div>
                     <img class="forecast-alert hidden" src="assets/warn.svg" alt="Warning Icon">
                 </div>
                 <div class="forecast-day">
-                    <div class="forecast-date"></div>
-                    <img class="forecast-icon" src="">
-                    <div class="forecast-temp"></div>
-                    <div class="forecast-desc"></div>
+                    <div class="forecast-date">--</div>
+                    <img class="forecast-icon" src="assets/placeholder.svg" alt="Loading icon">
+                    <div class="forecast-temp">--</div>
+                    <div class="forecast-desc">--</div>
                     <img class="forecast-alert hidden" src="assets/warn.svg" alt="Warning Icon">
                 </div>
                 <div class="forecast-day">
-                    <div class="forecast-date"></div>
-                    <img class="forecast-icon" src="">
-                    <div class="forecast-temp"></div>
-                    <div class="forecast-desc"></div>
+                    <div class="forecast-date">--</div>
+                    <img class="forecast-icon" src="assets/placeholder.svg" alt="Loading icon">
+                    <div class="forecast-temp">--</div>
+                    <div class="forecast-desc">--</div>
                     <img class="forecast-alert hidden" src="assets/warn.svg" alt="Warning Icon">
                 </div>
                 <div class="forecast-day">
-                    <div class="forecast-date"></div>
-                    <img class="forecast-icon" src="">
-                    <div class="forecast-temp"></div>
-                    <div class="forecast-desc"></div>
+                    <div class="forecast-date">--</div>
+                    <img class="forecast-icon" src="assets/placeholder.svg" alt="Loading icon">
+                    <div class="forecast-temp">--</div>
+                    <div class="forecast-desc">--</div>
                     <img class="forecast-alert hidden" src="assets/warn.svg" alt="Warning Icon">
                 </div>
                 <div class="forecast-day">
-                    <div class="forecast-date"></div>
-                    <img class="forecast-icon" src="">
-                    <div class="forecast-temp"></div>
-                    <div class="forecast-desc"></div>
+                    <div class="forecast-date">--</div>
+                    <img class="forecast-icon" src="assets/placeholder.svg" alt="Loading icon">
+                    <div class="forecast-temp">--</div>
+                    <div class="forecast-desc">--</div>
                     <img class="forecast-alert hidden" src="assets/warn.svg" alt="Warning Icon">
                 </div>
             </div>

--- a/js/wx.js
+++ b/js/wx.js
@@ -1,5 +1,5 @@
 // Import required functions from app.js
-import { formatTime, highlightUpdate, testMode, showSpinner, hideSpinner, showNotification } from './common.js';
+import { formatTime, highlightUpdate, testMode, showNotification } from './common.js';
 import { autoDarkMode, settings } from './settings.js';
 
 // Parameters
@@ -33,10 +33,9 @@ export function fetchPremiumWeatherData(lat, long, silentLoad = false) {
     lastLat = lat;
     lastLong = long;
 
-    // Show loading spinner, hide forecast container - only if not silent loading
+    // Show loading state on forecast container when not silent loading
     if (!silentLoad) {
-        showSpinner('prem-forecast-loading');
-        document.getElementById('prem-forecast-container').style.display = 'none';
+        document.getElementById('prem-forecast-container').classList.add('loading');
     }
 
     // Fetch and update weather data
@@ -83,11 +82,9 @@ export function fetchPremiumWeatherData(lat, long, silentLoad = false) {
                 updateAQI(lat, long);
             }
 
-            // Hide spinner and show forecast when data is loaded - only if not silent loading
+            // Remove loading state when data is loaded - only if not silent loading
             if (!silentLoad) {
-                hideSpinner('prem-forecast-loading');
-                document.getElementById('prem-forecast-container').style.display = '';
-                document.getElementById('prem-forecast-container').classList.remove('hidden');
+                document.getElementById('prem-forecast-container').classList.remove('loading');
             }
 
             // Update auto-dark mode if enabled
@@ -96,9 +93,9 @@ export function fetchPremiumWeatherData(lat, long, silentLoad = false) {
         .catch(error => {
             console.error('Error fetching forecast data: ', error);
 
-            // In case of error, hide spinner - only if not silent loading
+            // In case of error, remove loading state - only if not silent loading
             if (!silentLoad) {
-                hideSpinner('prem-forecast-loading');
+                document.getElementById('prem-forecast-container').classList.remove('loading');
             }
         });
 }
@@ -245,11 +242,9 @@ export function updatePremiumWeatherDisplay() {
             }
         }
     }
-    // Hide spinner, show forecast
+    // Ensure forecast is visible and remove loading state
     const forecastContainer = document.getElementById('prem-forecast-container');
-    const loadingSpinner = document.getElementById('prem-forecast-loading');
-    if (forecastContainer) forecastContainer.classList.remove('hidden');
-    if (loadingSpinner) loadingSpinner.style.display = 'none';
+    if (forecastContainer) forecastContainer.classList.remove('loading');
 
     // Update precipitation graph with time-based x-axis
     updatePrecipitationGraph();


### PR DESCRIPTION
## Summary
- replace forecast loading spinner with grey skeleton panels
- show placeholder dashes and icons while data loads
- streamline loading logic and add placeholder icon asset

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a274da4f58832b8b53750991289668