### PR TITLE
Highlight selected day in weather forecast

### DIFF
--- a/css/wx.css
+++ b/css/wx.css
@@ -208,16 +208,16 @@ body.dark-mode {
 
 /* Highlighted state for selected forecast day */
 .forecast-day.selected {
-    outline: 4px solid var(--accent-color, #ff7700);
+    outline: 4px solid var(--tesla-blue, #0077ff);
     outline-offset: 2px;
-    box-shadow: 0 0 20px rgba(255, 119, 0, 0.6);
+    box-shadow: 0 0 20px rgba(0, 119, 255, 0.6);
     transform: scale(1.05);
     transition: all 0.3s ease;
     z-index: 10;
 }
 
 body.dark-mode .forecast-day.selected {
-    box-shadow: 0 0 30px rgba(255, 119, 0, 0.8);
+    box-shadow: 0 0 30px rgba(0, 119, 255, 0.8);
 }
 
 #minutely-precip-container {
@@ -308,32 +308,6 @@ body.dark-mode .forecast-desc {
 
 .forecast-popup.show {
     display: block;
-}
-
-/* Visual connector between selected panel and popup */
-.forecast-popup-connector {
-    display: none;
-    position: fixed;
-    width: 3px;
-    background: linear-gradient(to bottom,
-        rgba(255, 119, 0, 0.8) 0%,
-        rgba(255, 119, 0, 0.6) 50%,
-        rgba(255, 119, 0, 0.8) 100%);
-    z-index: 999;
-    pointer-events: none;
-    box-shadow: 0 0 10px rgba(255, 119, 0, 0.5);
-}
-
-.forecast-popup-connector.show {
-    display: block;
-}
-
-body.dark-mode .forecast-popup-connector {
-    background: linear-gradient(to bottom,
-        rgba(255, 119, 0, 0.9) 0%,
-        rgba(255, 119, 0, 0.7) 50%,
-        rgba(255, 119, 0, 0.9) 100%);
-    box-shadow: 0 0 15px rgba(255, 119, 0, 0.7);
 }
 
 .forecast-popup-close {

--- a/js/wx.js
+++ b/js/wx.js
@@ -1406,11 +1406,9 @@ window.showPremiumPrecipGraph = function(dayIndex) {
 
     // Highlight the selected forecast day panel
     const forecastDays = document.querySelectorAll('#prem-forecast-container .forecast-day');
-    let selectedPanel = null;
     forecastDays.forEach((day, index) => {
         if (index === dayIndex) {
             day.classList.add('selected');
-            selectedPanel = day;
         } else {
             day.classList.remove('selected');
         }
@@ -1420,40 +1418,6 @@ window.showPremiumPrecipGraph = function(dayIndex) {
     const premPopup = document.querySelector('#weather .forecast-popup');
     if (premPopup) {
         premPopup.classList.add('show');
-    }
-
-    // Create and position visual connector between panel and popup
-    if (selectedPanel && premPopup) {
-        // Get or create connector element
-        let connector = document.getElementById('forecast-popup-connector');
-        if (!connector) {
-            connector = document.createElement('div');
-            connector.id = 'forecast-popup-connector';
-            connector.className = 'forecast-popup-connector';
-            document.body.appendChild(connector);
-        }
-
-        // Calculate positions after a small delay to ensure popup is rendered
-        setTimeout(() => {
-            const panelRect = selectedPanel.getBoundingClientRect();
-            const popupRect = premPopup.getBoundingClientRect();
-
-            // Calculate connector position (from center-bottom of panel to center-top of popup)
-            const panelCenterX = panelRect.left + panelRect.width / 2;
-            const panelBottomY = panelRect.bottom;
-            const popupCenterX = popupRect.left + popupRect.width / 2;
-            const popupTopY = popupRect.top;
-
-            // Position connector
-            const connectorLeft = (panelCenterX + popupCenterX) / 2;
-            const connectorTop = Math.min(panelBottomY, popupTopY);
-            const connectorHeight = Math.abs(popupTopY - panelBottomY);
-
-            connector.style.left = `${connectorLeft}px`;
-            connector.style.top = `${connectorTop}px`;
-            connector.style.height = `${connectorHeight}px`;
-            connector.classList.add('show');
-        }, 10);
     }
 
     // Calculate start/end of the selected day in local time
@@ -1672,10 +1636,6 @@ window.closePremiumPrecipPopup = function() {
     // Remove highlighting from all forecast day panels
     const forecastDays = document.querySelectorAll('#prem-forecast-container .forecast-day');
     forecastDays.forEach(day => day.classList.remove('selected'));
-
-    // Hide visual connector
-    const connector = document.getElementById('forecast-popup-connector');
-    if (connector) connector.classList.remove('show');
 }
 
 // Switches the weather image based on the type provided


### PR DESCRIPTION
When users click on a daily forecast panel to view hourly details, the selected panel is now highlighted with:
- Orange outline and glow effect
- Slight scale increase for emphasis
- Visual connector line between panel and popup

This makes it clear which day is being examined in the hourly forecast popup.

Changes:
- Added .forecast-day.selected CSS styling with outline, glow, and scale
- Modified showPremiumPrecipGraph() to highlight clicked panel
- Created dynamic visual connector element between panel and popup
- Modified closePremiumPrecipPopup() to remove highlighting and connector
- Supports both light and dark modes with appropriate styling