### PR TITLE
Fix weather section loading without GPS

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -988,7 +988,7 @@ window.showSection = function (sectionId) {
 
     // Handle weather section when GPS is not available
     if (sectionId === 'weather') {
-        if (gpsPermissionDenied || gpsFailureCount >= MAX_GPS_RETRIES) {
+        if (gpsPermissionDenied || gpsFailureCount >= MAX_GPS_RETRIES || lat === null || long === null) {
             console.log('GPS not available for weather data, attempting IP-based location fallback...');
             
             // Try to get IP-based location as fallback


### PR DESCRIPTION
When GPS is unavailable and the weather section is loaded via URL parameter on initial page load, there was a race condition where the code would check if GPS had failed, but GPS hadn't failed yet - it simply hadn't completed.

The check was:
  if (gpsPermissionDenied || gpsFailureCount >= MAX_GPS_RETRIES)

Both conditions would be false because GPS request was in-flight, causing the code to assume GPS was available when it wasn't, resulting in no weather data loading.

Fix: Also check if we have actual GPS coordinates before assuming GPS works:
  if (gpsPermissionDenied || gpsFailureCount >= MAX_GPS_RETRIES ||
      lat === null || long === null)

This ensures IP-based location fallback is used when coordinates aren't available yet, even if GPS hasn't explicitly failed. When GPS eventually succeeds, handlePositionUpdate() will automatically update the weather with GPS coordinates.