### PR TITLE
Increase forecast date font size from 10pt to 12pt

### DIFF
--- a/css/wx.css
+++ b/css/wx.css
@@ -245,7 +245,7 @@ body.dark-mode .forecast-day.rain img.forecast-icon {
 }
 
 .forecast-date {
-    font-size: 10pt;
+    font-size: 12pt;
     font-weight: 650;
     /* margin-bottom: 8px; */
     /* text-transform: uppercase; */
@@ -484,7 +484,7 @@ body.dark-mode .notification-icon img {
     }
     
     .forecast-date {
-        font-size: 10pt;
+        font-size: 12pt;
         margin-bottom: 5px;
     }
     


### PR DESCRIPTION
The date in the extended forecast daily panels is now more readable
while remaining slightly smaller than the temperature display (14pt).
Updated both desktop and mobile responsive styles.