### PR TITLE
Add satellite region selection and location override controls

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -806,6 +806,33 @@ body.dark-mode .network-icon {
     transition: background-color 0.3s, color 0.3s;
 }
 
+.settings-toggle-item.option-switch-container {
+    flex-direction: column;
+}
+
+.settings-helper-row {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    margin-top: 8px;
+}
+
+.settings-inline-button {
+    padding: 10px 16px;
+    border-radius: var(--button-radius);
+    border: none;
+    background-color: var(--button-bg);
+    color: var(--text-color);
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.settings-inline-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 .settings-toggle-item label {
     flex-grow: 1;
     cursor: inherit;

--- a/css/wx.css
+++ b/css/wx.css
@@ -63,6 +63,11 @@ body.dark-mode {
     color: var(--button-text);
 }
 
+.weather-switch button.disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
 .weather-switch::after {
     content: '';
     position: absolute;

--- a/index.html
+++ b/index.html
@@ -446,6 +446,20 @@
                     </div>
                 </div>
 
+                <div class="settings-toggle-item option-switch-container" data-setting="satellite-region">
+                    <label>Satellite Region</label>
+                    <div class="option-switch" id="satellite-region-options">
+                        <button class="option-button active" data-value="conus" onclick="toggleOptionSetting(this)">U.S.</button>
+                        <button class="option-button" data-value="canada" onclick="toggleOptionSetting(this)">Canada</button>
+                        <button class="option-button" data-value="mexico" onclick="toggleOptionSetting(this)">Mexico</button>
+                        <button class="option-button" data-value="europe" onclick="toggleOptionSetting(this)">Europe</button>
+                        <button class="option-button" data-value="china" onclick="toggleOptionSetting(this)">China</button>
+                    </div>
+                    <div class="settings-helper-row">
+                        <button type="button" id="satellite-location-button" class="settings-inline-button" onclick="enableSatelliteLocationMode()">Use current location</button>
+                    </div>
+                </div>
+
                 <div class="settings-toggle-item" data-setting="show-price-alt"
                     onclick="this.querySelector('input').click()">
                     <label>Stock Price and % Change</label>

--- a/js/app.js
+++ b/js/app.js
@@ -2,7 +2,7 @@
 import { srcUpdate, testMode, debugMode, isTestMode, updateTimeZone, GEONAMES_USERNAME, showNotification, gpsPermissionDenied, setGpsPermissionDenied, setUsingIPLocation } from './common.js';
 import { PositionSimulator } from './location.js';
 import { attemptLogin, leaveSettings, settings, isDriving, setDrivingState, enableLiveNewsUpdates, saveSetting } from './settings.js';
-import { fetchPremiumWeatherData, fetchCityData, SAT_URLS, forecastDataPrem, currentRainAlert, generateForecastDayElements, ensurePrecipitationGraphWidth } from './wx.js';
+import { fetchPremiumWeatherData, fetchCityData, forecastDataPrem, currentRainAlert, generateForecastDayElements, ensurePrecipitationGraphWidth, updateSatelliteFromSettings } from './wx.js';
 import { updateNetworkInfo, updatePingChart, startPingTest, getIPBasedLocation } from './net.js';
 import { setupNewsObserver, startNewsTimeUpdates, initializeNewsStorage } from './news.js';
 import { startStockUpdates, stopStockUpdates } from './stock.js';
@@ -949,8 +949,7 @@ window.showSection = function (sectionId) {
     // Satellite section
     if (sectionId === 'satellite') {
         // Load weather image when satellite section is shown
-        const weatherImage = document.getElementById('weather-image');
-        weatherImage.src = SAT_URLS.latest;
+        updateSatelliteFromSettings();
     } else {
         // Remove weather img src to force reload when switching back
         const weatherImage = document.getElementById('weather-image');


### PR DESCRIPTION
## Summary
- add satellite region sources for the Americas, Europe, and East Asia and auto-select them from user location
- add settings slider with manual region choices and a location override button to manage satellite imagery
- disable unavailable satellite imagery controls and refresh satellite images based on updated preferences

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69239fc35974832b91389f1787efd370)