### PR TITLE
Add location-aware satellite imagery selection

### DIFF
--- a/css/wx.css
+++ b/css/wx.css
@@ -59,6 +59,11 @@ body.dark-mode {
     transition: color 0.3s ease;
 }
 
+.weather-switch button.disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
 .weather-switch button.active {
     color: var(--button-text);
 }

--- a/index.html
+++ b/index.html
@@ -446,6 +446,19 @@
                     </div>
                 </div>
 
+                <div class="settings-toggle-item option-switch-container" data-setting="satellite-region" id="satellite-region-setting">
+                    <label>Satellite Region</label>
+                    <div class="option-switch">
+                        <button class="option-button" data-value="conus" onclick="toggleOptionSetting(this)">US</button>
+                        <button class="option-button" data-value="mexico" onclick="toggleOptionSetting(this)">Mexico</button>
+                        <button class="option-button" data-value="canada" onclick="toggleOptionSetting(this)">Canada</button>
+                        <button class="option-button" data-value="europe" onclick="toggleOptionSetting(this)">Europe</button>
+                        <button class="option-button" data-value="china" onclick="toggleOptionSetting(this)">China</button>
+                    </div>
+                    <p class="option-switch-helper">Choose satellite imagery manually or rely on your current location.</p>
+                    <button type="button" class="secondary-button" id="satellite-use-location">Use current location</button>
+                </div>
+
                 <div class="settings-toggle-item" data-setting="show-price-alt"
                     onclick="this.querySelector('input').click()">
                     <label>Stock Price and % Change</label>

--- a/js/app.js
+++ b/js/app.js
@@ -2,7 +2,7 @@
 import { srcUpdate, testMode, debugMode, isTestMode, updateTimeZone, GEONAMES_USERNAME, showNotification, gpsPermissionDenied, setGpsPermissionDenied, setUsingIPLocation } from './common.js';
 import { PositionSimulator } from './location.js';
 import { attemptLogin, leaveSettings, settings, isDriving, setDrivingState, enableLiveNewsUpdates, saveSetting } from './settings.js';
-import { fetchPremiumWeatherData, fetchCityData, SAT_URLS, forecastDataPrem, currentRainAlert, generateForecastDayElements, ensurePrecipitationGraphWidth } from './wx.js';
+import { fetchPremiumWeatherData, fetchCityData, forecastDataPrem, currentRainAlert, generateForecastDayElements, ensurePrecipitationGraphWidth, refreshSatelliteImage } from './wx.js';
 import { updateNetworkInfo, updatePingChart, startPingTest, getIPBasedLocation } from './net.js';
 import { setupNewsObserver, startNewsTimeUpdates, initializeNewsStorage } from './news.js';
 import { startStockUpdates, stopStockUpdates } from './stock.js';
@@ -949,8 +949,7 @@ window.showSection = function (sectionId) {
     // Satellite section
     if (sectionId === 'satellite') {
         // Load weather image when satellite section is shown
-        const weatherImage = document.getElementById('weather-image');
-        weatherImage.src = SAT_URLS.latest;
+        refreshSatelliteImage();
     } else {
         // Remove weather img src to force reload when switching back
         const weatherImage = document.getElementById('weather-image');

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,7 +1,7 @@
 // Imports
 import { updateNews, setShareButtonsVisibility, initializeNewsStorage } from './news.js';
 import { updateNetChartAxisColors } from './net.js';
-import { updatePremiumWeatherDisplay } from './wx.js';
+import { updatePremiumWeatherDisplay, setSatelliteRegion, setSatelliteAutoMode, applyAutoSatelliteRegion } from './wx.js';
 import { startStockUpdates, stopStockUpdates } from './stock.js';
 import { forecastDataPrem, lastLat, lastLong, updateRainChartAxisColors } from './wx.js';
 
@@ -30,6 +30,8 @@ const defaultSettings = {
     "24-hour-time": false,
     "imperial-units": true,
     "map-choice": 'waze',
+    "satellite-region": 'conus',
+    "satellite-auto-location": true,
     "show-wind-radar": false,
     "show-hourly-stripes": true,
     // Stocks
@@ -1026,6 +1028,18 @@ function updateSetting(key, value) {
         case 'show-hourly-stripes':
             updatePremiumWeatherDisplay();
             break;
+        case 'satellite-region':
+            setSatelliteAutoMode(false);
+            setSatelliteRegion(value);
+            setControlEnable('satellite-region', true);
+            break;
+        case 'satellite-auto-location':
+            setSatelliteAutoMode(value);
+            setControlEnable('satellite-region', !value);
+            if (value) {
+                applyAutoSatelliteRegion();
+            }
+            break;
         case 'show-stock-indicator':
             // Special handling for the master switch
             // If it's being enabled, start updates
@@ -1316,7 +1330,11 @@ window.toggleOptionSetting = function(button) {
         // Convert value to boolean
         value = (value === 'english');
     }
-    
+
+    if (key === 'satellite-region') {
+        saveSetting('satellite-auto-location', false);
+    }
+
     // Store the setting
     saveSetting(key, value);
 }
@@ -1330,3 +1348,13 @@ window.updateSettingFrom = function(element) {
         saveSetting(key, value);
     }
 }
+
+// Satellite location shortcut
+document.addEventListener('DOMContentLoaded', () => {
+    const useLocationButton = document.getElementById('satellite-use-location');
+    if (useLocationButton) {
+        useLocationButton.addEventListener('click', () => {
+            saveSetting('satellite-auto-location', true);
+        });
+    }
+});


### PR DESCRIPTION
## Summary
- add regional satellite imagery sources for the satellite pane and gray out unavailable modes
- allow the settings page to pick a manual satellite region or rely on current location to auto-select
- refresh satellite display based on the active region instead of the fixed CONUS feed

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69239fc35974832b91389f1787efd370)