### PR TITLE
Add dark mode styling for NOAA radar images

### DIFF
--- a/css/wx.css
+++ b/css/wx.css
@@ -682,3 +682,7 @@ body.dark-mode .notification-icon img {
     border: 2px solid var(--separator-color);
     display: block;
 }
+
+body.dark-mode .radar-image {
+    filter: invert(1) hue-rotate(180deg);
+}


### PR DESCRIPTION
Apply invert and hue-rotate filters to radar images in dark mode to make them visible against dark backgrounds while preserving the color scheme and meaning of precipitation intensity indicators.