### PR TITLE
Add Waze position overlay indicator

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1243,3 +1243,58 @@ body.dark-mode .option-button:hover:not(.active) {
         height: 100%;
     }
 }
+
+.waze-position-indicator {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 44px;
+    height: 44px;
+    transform: translate(-50%, -50%);
+    border: 2px solid rgba(255, 255, 255, 0.85);
+    border-radius: 50%;
+    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.35);
+    pointer-events: none;
+    z-index: 6;
+    display: none;
+}
+
+.waze-position-indicator::before,
+.waze-position-indicator::after {
+    content: '';
+    position: absolute;
+    background: rgba(255, 255, 255, 0.9);
+}
+
+.waze-position-indicator::before {
+    top: 50%;
+    left: -10px;
+    right: -10px;
+    height: 2px;
+    transform: translateY(-50%);
+}
+
+.waze-position-indicator::after {
+    left: 50%;
+    top: -10px;
+    bottom: -10px;
+    width: 2px;
+    transform: translateX(-50%);
+}
+
+.waze-position-dot {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 12px;
+    height: 12px;
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+    background: var(--tesla-blue);
+    box-shadow: 0 0 10px rgba(30, 163, 255, 0.9);
+}
+
+body.dark-mode .waze-position-indicator {
+    border-color: rgba(255, 255, 255, 0.75);
+    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.6);
+}

--- a/index.html
+++ b/index.html
@@ -175,6 +175,9 @@
                     </div>
                 </div>
                 <button id="waze-reload-btn" class="waze-reload-btn" onclick="updateMapFrame(true)" title="Reload map at current location">&#x21bb; Reload</button>
+                <div id="waze-position-indicator" class="waze-position-indicator" aria-hidden="true">
+                    <div class="waze-position-dot"></div>
+                </div>
                 <iframe id="teslawaze" src="" allow="geolocation" loading="lazy"></iframe>
             </div>
         </div>

--- a/js/app.js
+++ b/js/app.js
@@ -938,6 +938,12 @@ window.updateMapFrame = function (force = false) {
     if (testModeMsg) testModeMsg.style.display = 'none';
     const reloadBtn = document.getElementById('waze-reload-btn');
     if (reloadBtn) reloadBtn.style.display = settings["map-choice"] === 'waze' ? '' : 'none';
+
+    const wazePositionIndicator = document.getElementById('waze-position-indicator');
+    if (wazePositionIndicator) {
+        const showIndicator = settings["map-choice"] === 'waze' && lat !== null && long !== null;
+        wazePositionIndicator.style.display = showIndicator ? '' : 'none';
+    }
 }
 
 // Function to load an external URL in a new tab or frame


### PR DESCRIPTION
### Motivation
- Provide a visible, non-interactive marker superimposed on the Waze embed so the vehicle's current position is clear relative to the map viewport without interacting with the iframe.

### Description
- Inserted a `#waze-position-indicator` element (with inner `.waze-position-dot`) adjacent to the Waze iframe in `index.html` to act as the overlay marker.
- Added styling to `css/styles.css` for a crosshair ring and center dot including dark-mode contrast tweaks and `pointer-events: none` so it remains non-interactive and sits above the iframe.
- Modified `updateMapFrame()` in `js/app.js` to toggle the indicator's visibility only when `settings["map-choice"] === 'waze'` and valid `lat`/`long` are available.
- Kept the indicator hidden by default and controlled purely by the page script to avoid affecting non-Waze map modes.

### Testing
- Ran repository inspections using `rg --files` and `rg`/`sed -n` to locate and view the modified files, which returned the expected results and file snippets.
- Verified the code changes with `git diff` and reviewed context using `nl -ba` on `index.html`, `js/app.js`, and `css/styles.css`, which showed the inserted element, CSS, and map-frame toggle logic.
- Staged and committed the changes with `git add` and `git commit`, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe57f43978832ba19b0ade67448695)