### PR TITLE
Add car position indicator overlay for Waze map

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -845,6 +845,37 @@ body.dark-mode #teslawaze {
     opacity: 1;
 }
 
+/* Car position indicator overlay (sits on top of the Waze iframe) */
+.car-position-indicator {
+    display: none;
+    position: absolute;
+    width: 32px;
+    height: 32px;
+    margin-left: -16px;
+    margin-top: -16px;
+    pointer-events: none;
+    z-index: 9;
+    will-change: left, top, transform;
+    filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.55));
+}
+
+.car-position-indicator svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.car-position-indicator path {
+    fill: var(--tesla-blue, #1976d2);
+    stroke: #ffffff;
+    stroke-width: 1.6;
+    stroke-linejoin: round;
+}
+
+.car-position-indicator.no-heading path {
+    fill: #888;
+}
+
 /* Modal Login Dialog */
 .modal {
     display: none;

--- a/css/styles.css
+++ b/css/styles.css
@@ -876,6 +876,23 @@ body.dark-mode #teslawaze {
     fill: #888;
 }
 
+/* Map selector floats over the top of the iframe */
+#in-map-toggle {
+    position: absolute;
+    top: 8px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10;
+    padding: 4px;
+    background-color: var(--bg-color);
+    border-radius: var(--button-radius);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+}
+
+#in-map-toggle .option-switch {
+    background-color: var(--button-highlight);
+}
+
 /* Modal Login Dialog */
 .modal {
     display: none;

--- a/index.html
+++ b/index.html
@@ -176,6 +176,11 @@
                 </div>
                 <button id="waze-reload-btn" class="waze-reload-btn" onclick="updateMapFrame(true)" title="Reload map at current location">&#x21bb; Reload</button>
                 <iframe id="teslawaze" src="" allow="geolocation" loading="lazy"></iframe>
+                <div id="car-position-indicator" class="car-position-indicator" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M12 2 L4 22 L12 17 L20 22 Z" />
+                    </svg>
+                </div>
             </div>
         </div>
 

--- a/js/app.js
+++ b/js/app.js
@@ -548,6 +548,74 @@ async function handlePositionUpdate(position) {
             lastMapLong = long;
         }
     }
+
+    updateCarPositionIndicator();
+}
+
+// Must match the zoom parameter used in updateMapFrame()'s Waze embed URL.
+const WAZE_EMBED_ZOOM = 13;
+
+function updateCarPositionIndicator() {
+    const indicator = document.getElementById('car-position-indicator');
+    if (!indicator) return;
+
+    if (settings["map-choice"] !== 'waze' ||
+        lat === null || long === null ||
+        lastMapLat === null || lastMapLong === null) {
+        indicator.style.display = 'none';
+        return;
+    }
+
+    const iframe = document.getElementById('teslawaze');
+    if (!iframe) {
+        indicator.style.display = 'none';
+        return;
+    }
+    const iframeW = iframe.offsetWidth;
+    const iframeH = iframe.offsetHeight;
+    if (iframeW <= 0 || iframeH <= 0) {
+        indicator.style.display = 'none';
+        return;
+    }
+
+    // Web Mercator meters/pixel at the embed's zoom level and the map's
+    // current center latitude.
+    const metersPerPixel = 156543.03392 *
+        Math.cos(lastMapLat * Math.PI / 180) /
+        Math.pow(2, WAZE_EMBED_ZOOM);
+
+    const dxMeters = (long - lastMapLong) * 111320 *
+        Math.cos(lastMapLat * Math.PI / 180);
+    const dyMeters = (lat - lastMapLat) * 110540;
+
+    // Screen y grows downward; positive latitude is up on the map.
+    const dxPx = dxMeters / metersPerPixel;
+    const dyPx = -dyMeters / metersPerPixel;
+
+    const indicatorHalf = 16;
+    const leftPx = iframe.offsetLeft + iframeW / 2 + dxPx;
+    const topPx = iframe.offsetTop + iframeH / 2 + dyPx;
+    if (leftPx < iframe.offsetLeft - indicatorHalf ||
+        leftPx > iframe.offsetLeft + iframeW + indicatorHalf ||
+        topPx < iframe.offsetTop - indicatorHalf ||
+        topPx > iframe.offsetTop + iframeH + indicatorHalf) {
+        indicator.style.display = 'none';
+        return;
+    }
+
+    indicator.style.left = leftPx + 'px';
+    indicator.style.top = topPx + 'px';
+
+    if (lastKnownHeading !== null && lastKnownHeading !== undefined &&
+        !isNaN(lastKnownHeading)) {
+        indicator.style.transform = `rotate(${lastKnownHeading}deg)`;
+        indicator.classList.remove('no-heading');
+    } else {
+        indicator.style.transform = 'rotate(0deg)';
+        indicator.classList.add('no-heading');
+    }
+
+    indicator.style.display = 'block';
 }
 
 // Function called when user starts driving
@@ -938,6 +1006,10 @@ window.updateMapFrame = function (force = false) {
     if (testModeMsg) testModeMsg.style.display = 'none';
     const reloadBtn = document.getElementById('waze-reload-btn');
     if (reloadBtn) reloadBtn.style.display = settings["map-choice"] === 'waze' ? '' : 'none';
+
+    // The map center just changed (or we switched away from Waze), so refresh
+    // the overlay. Defer to next frame so the iframe layout settles first.
+    requestAnimationFrame(() => updateCarPositionIndicator());
 }
 
 // Function to load an external URL in a new tab or frame
@@ -1418,6 +1490,7 @@ document.addEventListener('DOMContentLoaded', async function () {
     window.addEventListener('resize', () => {
         updateScrollIndicators();
         updateMobileSectionVisibility();
+        updateCarPositionIndicator();
     });
 
     // Update mobile section visibility on page load


### PR DESCRIPTION
## Summary
This PR adds a visual car position indicator that overlays on top of the Waze map iframe, showing the vehicle's current location and heading direction in real-time.

## Key Changes
- **New `updateCarPositionIndicator()` function**: Calculates the car's screen position relative to the Waze map center using Web Mercator projection math, accounting for zoom level and latitude-based distortion
- **Position calculation logic**: Converts lat/long deltas to pixel offsets using proper geographic formulas (111320 m/degree longitude, 110540 m/degree latitude, with cosine correction for latitude)
- **Heading visualization**: Rotates the indicator SVG based on `lastKnownHeading`, with a visual distinction (gray color) when heading data is unavailable
- **Smart visibility**: Hides the indicator when:
  - Not using Waze map
  - Car position data is unavailable
  - Indicator would be off-screen
  - Iframe hasn't loaded or has zero dimensions
- **SVG indicator**: Added a simple arrow/chevron shape (32x32px) with drop shadow, styled with Tesla blue and white stroke
- **Integration points**: 
  - Called from `handlePositionUpdate()` when GPS position changes
  - Called from `updateMapFrame()` when map center changes
  - Called on window resize to recalculate positions
  - Deferred with `requestAnimationFrame()` to allow layout to settle

## Implementation Details
- Uses `WAZE_EMBED_ZOOM` constant (13) to match the embed's zoom level for accurate pixel calculations
- Implements Web Mercator projection: `metersPerPixel = 156543.03392 * cos(lat) / 2^zoom`
- Indicator is positioned absolutely within the map container with `pointer-events: none` to avoid blocking map interaction
- CSS includes `will-change` optimization for smooth animation of position and rotation

https://claude.ai/code/session_01AswxY5KzexBLDMnrnswPCj