### PR TITLE
Revert floating overlay styles for #in-map-toggle

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -876,23 +876,6 @@ body.dark-mode #teslawaze {
     fill: #888;
 }
 
-/* Map selector floats over the top of the iframe */
-#in-map-toggle {
-    position: absolute;
-    top: 8px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 10;
-    padding: 4px;
-    background-color: var(--bg-color);
-    border-radius: var(--button-radius);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
-}
-
-#in-map-toggle .option-switch {
-    background-color: var(--button-highlight);
-}
-
 /* Modal Login Dialog */
 .modal {
     display: none;


### PR DESCRIPTION
## Summary
- Removes the absolutely-positioned overlay styles for `#in-map-toggle` introduced in #424, which left the map selector hovering over the embedded Waze/satellite maps with an opaque background pill instead of clearing them.
- Restores the previous in-flow layout (selector sits above the iframe, no overlap).
- Keeps the rest of #424 (car position indicator overlay) intact.

## Test plan
- [ ] Open the Dashboard section and confirm the map selector sits above the embedded map without overlapping it.
- [ ] Toggle between Waze and the satellite embed and confirm the selector is still readable and not floating on top of the map.
- [ ] Confirm the car position indicator still renders correctly on the Waze map.

https://claude.ai/code/session_01Gk21RFZMAWc9P15CNuA6Rr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk21RFZMAWc9P15CNuA6Rr)_